### PR TITLE
fix: adjust payment method examples on swagger ui

### DIFF
--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -870,9 +870,9 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": ["pix", "card", "boleto", "cash", "deposit"],
-                      "example": ["pix", "card"]
-                    }
+                      "enum": ["pix", "card", "boleto", "cash", "deposit"]
+                    },
+                    "example": ["pix", "card"]
                   }
                 }
               }
@@ -1100,9 +1100,9 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": ["pix", "card", "boleto", "cash", "deposit"],
-                      "example": ["pix", "card"]
-                    }
+                      "enum": ["pix", "card", "boleto", "cash", "deposit"]
+                    },
+                    "example": ["pix", "card"]
                   }
                 }
               }


### PR DESCRIPTION
Essa PR corrige a exibição/exemplo do tipo `payment_methods` no swagger ui.

Ex.: `POST /products`
Atualmente o tipo está como `Array<Array<PaymentMethodsEnum>>`,
e o correto seria `Array<PaymentMethodsEnum>`.

Atual:
```json
{
  "name": "Luminária Pendente",
  "description": "Essa é a melhor luminária do mundo. Você não vai se arrepender.",
  "is_new": true,
  "price": 45000,
  "accept_trade": true,
  "payment_methods": [ // Array
    [ // Array
      "pix", // PaymentMethodEnum
      "card"
    ]
  ]
}
```

Correção deste PR:
```json
{
  "name": "Luminária Pendente",
  "description": "Essa é a melhor luminária do mundo. Você não vai se arrepender.",
  "is_new": true,
  "price": 45000,
  "accept_trade": true,
  "payment_methods": [ // Array
    "pix", // PaymentMethodEnum
    "card"
  ]
}
```